### PR TITLE
fix: fix TextPacketSendAfterEvent is not called

### DIFF
--- a/src/Event/Packet/TextPacketEvent.cc
+++ b/src/Event/Packet/TextPacketEvent.cc
@@ -26,7 +26,7 @@ LL_TYPE_INSTANCE_HOOK(
         return;
     }
     origin(identifier, packet);
-    auto afterEvent = TextPacketSendBeforeEvent(*this, identifier, packet);
+    auto afterEvent = TextPacketSendAfterEvent(*this, identifier, packet);
     ll::event::EventBus::getInstance().publish(afterEvent);
 }
 


### PR DESCRIPTION
## What does this PR do?

Fix TextPacketSendAfterEvent is not called

## Which issues does this PR resolve?

TextPacketSendAfterEvent is not called

## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] Your code follows [LeviLamina C++ Style Guide](https://github.com/LiteLDev/LeviLamina/wiki/CPP-Style-Guide)
- [] You have tested all functions
- [x] You have not used code without license
- [x] You have added statement for third-party code
